### PR TITLE
Chocolatey Uninstall Issue

### DIFF
--- a/Gradle/gradle.nuspec
+++ b/Gradle/gradle.nuspec
@@ -27,9 +27,6 @@ Learn more about what makes Gradle a compelling choice for build automation or g
 The team is always working to improve the overall performance of Gradle, and this release does not disappoint. Gradle's configuration time has dropped considerably through the application of some careful optimizations. The Gradle build itself has seen a 50% reduction in configuration time.
 
 Find the complete release notes following the [link](https://docs.gradle.org/current/release-notes).</releaseNotes>
-    <dependencies>
-      <dependency id="chocolatey" version="0.9.9" />
-    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/Gradle/tools/chocolateyinstall.ps1
+++ b/Gradle/tools/chocolateyinstall.ps1
@@ -1,8 +1,17 @@
-﻿$packageName = 'gradle'
+﻿
+[string]$chocoVersion = $(choco --version)
+[string]$majorRelease = $chocoVersion.Split('.')[1]
+[string]$minorRelease = $chocoVersion.Split('.')[2]
+if (-not $majorRelease.Equals("9") -or -not $minorRelease.Equals("9"))
+{
+    throw "This package requires Chocolatey 0.9.9 and will not work with any other version."
+}
+
+$packageName = 'gradle'
 $version = $env:chocolateyPackageVersion
 $url = "https://services.gradle.org/distributions/gradle-$version-bin.zip"
-
 $installDir = Split-Path -parent $MyInvocation.MyCommand.Definition
+
 Install-ChocolateyZipPackage $packageName $url $installDir
 
 $gradle_home = Join-Path $installDir "$packageName-$version"

--- a/Gradle/tools/chocolateyinstall.ps1
+++ b/Gradle/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@
 [string]$minorRelease = $chocoVersion.Split('.')[2]
 if (-not $majorRelease.Equals("9") -or -not $minorRelease.Equals("9"))
 {
-    throw "This package requires Chocolatey 0.9.9 and will not work with any other version."
+    write-host "WARNING: This package has only been tested with Chocolatey 0.9.9" -f "Yellow"
 }
 
 $packageName = 'gradle'


### PR DESCRIPTION
Removing behavior that uninstalls and reinstalls the package manager and adding a warning for anyone not using Chocolatey 0.9.9.
