### PR TITLE
Add package upgrade script

### DIFF
--- a/Gradle/tools/chocolateybeforemodify.ps1
+++ b/Gradle/tools/chocolateybeforemodify.ps1
@@ -1,0 +1,7 @@
+﻿
+$packageName    = $env:chocolateyPackageName
+$packageVersion = $env:chocolateyPackageVersion
+$toolsDir       = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$fileLocation   = Join-Path $toolsDir "$packageName-$packageVersion"
+
+Remove-Item $fileLocation -Recurse -Force


### PR DESCRIPTION
Remove an older version of Gradle before newer version is installed
during package upgrade.

How it has been tested,
Scenario1: without chocolateybeforemodify.ps1
> 1. Install Gradle 2.13 (without upgrade script bundled during cpack)
> 2. Upgrade to Gradle 2.14
> 3. Both gradle-2.13 and gradle-2.14 exist in `<chocolateyPackageFolder>/tools/`

Scenario2: with chocolateybeforemodify.ps1
> 1. Install Gradle 2.13 (with upgrade script bundled during cpack)
> 2. Modify nuspec to indicate version as 2.14
> 3. Bundle .nupkg.
> 4. Upgrade to Gradle 2.14 using bundled .nupkg.
> 5. Only gradle-2.14 exists in `<chocolateyPackageFolder>/tools/`